### PR TITLE
Go modules support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/crossnokaye/modbus
 
 go 1.15
 
-require (
-	github.com/goburrow/modbus v0.1.0
-	github.com/goburrow/serial v0.1.0
-)
+require github.com/goburrow/serial v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/crossnokaye/modbus
+
+go 1.15
+
+require (
+	github.com/goburrow/modbus v0.1.0
+	github.com/goburrow/serial v0.1.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/goburrow/modbus v0.1.0 h1:DejRZY73nEM6+bt5JSP6IsFolJ9dVcqxsYbpLbeW/ro=
+github.com/goburrow/modbus v0.1.0/go.mod h1:Kx552D5rLIS8E7TyUwQ/UdHEqvX5T8tyiGBTlzMcZBg=
+github.com/goburrow/serial v0.1.0 h1:v2T1SQa/dlUqQiYIT8+Cu7YolfqAi3K96UmhwYyuSrA=
+github.com/goburrow/serial v0.1.0/go.mod h1:sAiqG0nRVswsm1C97xsttiYCzSLBmUZ/VSlVLZJ8haA=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/goburrow/modbus v0.1.0 h1:DejRZY73nEM6+bt5JSP6IsFolJ9dVcqxsYbpLbeW/ro=
-github.com/goburrow/modbus v0.1.0/go.mod h1:Kx552D5rLIS8E7TyUwQ/UdHEqvX5T8tyiGBTlzMcZBg=
 github.com/goburrow/serial v0.1.0 h1:v2T1SQa/dlUqQiYIT8+Cu7YolfqAi3K96UmhwYyuSrA=
 github.com/goburrow/serial v0.1.0/go.mod h1:sAiqG0nRVswsm1C97xsttiYCzSLBmUZ/VSlVLZJ8haA=

--- a/test/README.md
+++ b/test/README.md
@@ -1,4 +1,4 @@
-System testing for [modbus library](https://github.com/goburrow/modbus)
+System testing for [modbus library](https://github.com/crossnokaye/modbus)
 
 Modbus simulator
 ----------------

--- a/test/asciiclient_test.go
+++ b/test/asciiclient_test.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/goburrow/modbus"
+	"github.com/crossnokaye/modbus"
 )
 
 const (
@@ -17,6 +17,8 @@ const (
 )
 
 func TestASCIIClient(t *testing.T) {
+
+
 	// Diagslave does not support broadcast id.
 	handler := modbus.NewASCIIClientHandler(asciiDevice)
 	handler.SlaveId = 17

--- a/test/asciiclient_test.go
+++ b/test/asciiclient_test.go
@@ -17,8 +17,6 @@ const (
 )
 
 func TestASCIIClient(t *testing.T) {
-
-
 	// Diagslave does not support broadcast id.
 	handler := modbus.NewASCIIClientHandler(asciiDevice)
 	handler.SlaveId = 17

--- a/test/client.go
+++ b/test/client.go
@@ -7,7 +7,7 @@ package test
 import (
 	"testing"
 
-	"github.com/goburrow/modbus"
+	"github.com/crossnokaye/modbus"
 )
 
 func ClientTestReadCoils(t *testing.T, client modbus.Client) {
@@ -67,7 +67,7 @@ func ClientTestWriteSingleCoil(t *testing.T, client modbus.Client) {
 
 func ClientTestWriteSingleRegister(t *testing.T, client modbus.Client) {
 	// Write register 2 to 00 03 hex
-	address := uint16(0x0001)
+	address := uint32(0x0001)
 	value := uint16(0x0003)
 	results, err := client.WriteSingleRegister(address, value)
 	if err != nil {

--- a/test/rtuclient_test.go
+++ b/test/rtuclient_test.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/goburrow/modbus"
+	"github.com/crossnokaye/modbus"
 )
 
 const (

--- a/test/tcpclient_test.go
+++ b/test/tcpclient_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goburrow/modbus"
+	"github.com/crossnokaye/modbus"
 )
 
 const (
@@ -18,12 +18,12 @@ const (
 )
 
 func TestTCPClient(t *testing.T) {
-	client := modbus.TCPClient(tcpDevice)
+	client := modbus.TCPClient(tcpDevice, time.Second, time.Second)
 	ClientTestAll(t, client)
 }
 
 func TestTCPClientAdvancedUsage(t *testing.T) {
-	handler := modbus.NewTCPClientHandler(tcpDevice)
+	handler := modbus.NewTCPClientHandler(tcpDevice, time.Second, time.Second)
 	handler.Timeout = 5 * time.Second
 	handler.SlaveId = 1
 	handler.Logger = log.New(os.Stdout, "tcp: ", log.LstdFlags)


### PR DESCRIPTION
This patch upgrades `modbus` to use Go modules. The `test` subpackage's imports are rewritten to be self-referential so the mod file does not pull in the fork's source as a dependency.