### PR TITLE
update unit-id validation for broadcast addrs

### DIFF
--- a/tcpclient.go
+++ b/tcpclient.go
@@ -97,8 +97,11 @@ func (mb *tcpPackager) Verify(aduRequest []byte, aduResponse []byte) (err error)
 		return
 	}
 	// Unit id (1 byte)
-	if aduResponse[6] != aduRequest[6] {
-		err = fmt.Errorf("modbus: response unit id '%v' does not match request '%v'", aduResponse[6], aduRequest[6])
+	requestID := aduRequest[6]
+	responseID := aduRequest[6]
+	// only validate unit ids 1-247 which are not broadcast addresses (0, 248-255)
+	if requestID >= 1 && requestID <= 247 && responseID != requestID {
+		err = fmt.Errorf("modbus: response unit id '%v' does not match request '%v'", responseID, requestID)
 		return
 	}
 	return


### PR DESCRIPTION
Communication with the PMC-1 devices (currently installed at Henderson B1) uses a unit ID of 255, which is a broadcast address in Modbus terms.  Unit IDs in the range of 1-247 are non-broadcast addresses and either 0 or 248-255 for broadcast.  The current protocol stack validates that the unit ID matches between the request and response which fails when communicating with devices configured with a broadcast address.  This PR disables the unit ID validation for devices using a unit ID in the set of broadcast addresses.